### PR TITLE
add wasi-http-attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/wit-bindgen-http",
     "crates/wasm-http-tools",
     "crates/wasi-async-runtime",
+    "crates/wasi-http-attributes",
 ]
 resolver = "2"
 

--- a/crates/openapi-bindgen/src/lib.rs
+++ b/crates/openapi-bindgen/src/lib.rs
@@ -10,30 +10,30 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, future_incompatible, unreachable_pub)]
 
-use std::str::FromStr;
+// use std::str::FromStr;
 
-use openapiv3::OpenAPI;
+// use openapiv3::OpenAPI;
 
-struct Parser {
-    open_api: OpenAPI,
-}
+// struct Parser {
+//     open_api: OpenAPI,
+// }
 
-impl Parser {
-    /// Convert the parsed OpenAPI definition to WIT.
-    pub fn generate_wit(&self) -> Wit {
-        todo!();
-    }
-}
+// impl Parser {
+//     /// Convert the parsed OpenAPI definition to WIT.
+//     pub fn generate_wit(&self) -> Wit {
+//         todo!();
+//     }
+// }
 
-impl FromStr for Parser {
-    type Err = std::io::Error;
+// impl FromStr for Parser {
+//     type Err = std::io::Error;
 
-    /// Take a string of JSON and attempt to parse it as an OpenAPI definition
-    fn from_str(data: &str) -> Result<Self, Self::Err> {
-        let open_api: OpenAPI = serde_json::from_str(data).expect("Could not deserialize input");
-        Ok(Self { open_api })
-    }
-}
+//     /// Take a string of JSON and attempt to parse it as an OpenAPI definition
+//     fn from_str(data: &str) -> Result<Self, Self::Err> {
+//         let open_api: OpenAPI = serde_json::from_str(data).expect("Could not deserialize input");
+//         Ok(Self { open_api })
+//     }
+// }
 
-/// The generated Wit document
-struct Wit {}
+// /// The generated Wit document
+// struct Wit {}

--- a/crates/wasi-http-attributes/Cargo.toml
+++ b/crates/wasi-http-attributes/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "wasi-http-attributes"
+description = "Proc Macro attributes for the WASI HTTP Proxy World."
+version = "1.0.0"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/rust-cli/paw"
+homepage = "https://github.com/rust-cli/paw"
+documentation = "https://docs.rs/wasi-http-attributes"
+authors = ["Yosh Wuyts <rust@yosh.is>"]
+categories = ["command-line-interface", "command-line-utilities", "parsing"]
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0.5", features = ["full", "extra-traits"] }
+proc-macro2 = { version = "1.0.2", features = ["nightly"] }
+quote = "1.0.2"

--- a/crates/wasi-http-attributes/Cargo.toml
+++ b/crates/wasi-http-attributes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasi-http-attributes"
 description = "Proc Macro attributes for the WASI HTTP Proxy World."
-version = "1.0.0"
+version = "0.1.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-cli/paw"

--- a/crates/wasi-http-attributes/README.md
+++ b/crates/wasi-http-attributes/README.md
@@ -1,0 +1,44 @@
+# wasi-http-attributes
+Proc macro attributes for the [Paw](https://github.com/yoshuawuyts/wasm-http-tools) crate. See the
+[Paw](https://docs.rs/paw) documentation for more details.
+
+## Installation
+
+```sh
+$ cargo add wasi-http-attributes
+```
+
+## Safety
+This crate uses ``#![deny(unsafe_code)]`` to ensure everything is implemented in 100% Safe Rust.
+
+## Contributing
+Want to join us? Check out our [The "Contributing" section of the
+guide][contributing] and take a look at some of these issues:
+
+- [Issues labeled "good first issue"][good-first-issue]
+- [Issues labeled "help wanted"][help-wanted]
+
+#### Conduct
+
+The wasi-http-attributes project adheres to the [Contributor Covenant Code of
+Conduct](https://github.com/yoshuawuyts/wasm-http-tools/blob/master/.github/CODE_OF_CONDUCT.md).  This
+describes the minimum behavior expected from all contributors.
+
+## License
+Licensed under either of
+
+ * Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+#### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[releases]: https://github.com/yoshuawuyts/wasm-http-tools/releases
+[contributing]: https://github.com/yoshuawuyts/wasm-http-tools/blob/master/.github/CONTRIBUTING.md
+[good-first-issue]: https://github.com/yoshuawuyts/wasm-http-tools/labels/good%20first%20issue
+[help-wanted]: https://github.com/yoshuawuyts/wasm-http-tools/labels/help%20wanted

--- a/crates/wasi-http-attributes/src/lib.rs
+++ b/crates/wasi-http-attributes/src/lib.rs
@@ -1,0 +1,75 @@
+//! Macros for the WASI HTTP Proxy world.
+
+#![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
+#![deny(missing_debug_implementations, nonstandard_style)]
+#![recursion_limit = "512"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+
+#[proc_macro_attribute]
+pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let ret = &input.sig.output;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let asyncness = &input.sig.asyncness;
+    let attrs = &input.attrs;
+
+    if name != "main" {
+        let tokens = quote_spanned! { name.span() =>
+            compile_error!("only fn main can be tagged with #[wasi_http_attributes::main]");
+        };
+        return TokenStream::from(tokens);
+    }
+
+    let end = match ret {
+        syn::ReturnType::Default => quote! {.unwrap()},
+        _ => quote! {?},
+    };
+
+    let inputs = &input.sig.inputs;
+    let result = match inputs.len() {
+        0 => {
+            quote! {
+                #(#attrs)*
+                #asyncness fn main() #ret {
+                    #body
+                }
+            }
+        }
+        1 => {
+            let arg = match inputs.first().unwrap() {
+                syn::FnArg::Typed(arg) => arg,
+                _ => {
+                    let tokens = quote_spanned! { inputs.span() =>
+                        compile_error!("fn main should take a fully formed argument");
+                    };
+                    return TokenStream::from(tokens);
+                }
+            };
+            let arg_name = &arg.pat;
+            let arg_type = &arg.ty;
+            quote! {
+                #(#attrs)*
+                #asyncness fn main() #ret {
+                    let #arg_name = <#arg_type as wasi_http_attributes::ParseArgs>::parse_args()#end;
+                    #body
+                }
+
+            }
+        }
+        _ => {
+            let tokens = quote_spanned! { inputs.span() =>
+                compile_error!("fn main can take 0 or 1 arguments");
+            };
+            return TokenStream::from(tokens);
+        }
+    };
+
+    result.into()
+}


### PR DESCRIPTION
I should pick this up again later; but the idea is that we can take [this example](https://github.com/sunfishcode/hello-wasi-http/blob/main/src/lib.rs#L10) and rewrite it like so:

```rust
pub use bindings::wasi::http::types::{
    Fields, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
};

#[wasi_http_attributes::main]
fn main(req: IncomingRequest, res: ResponseOutparam) {
    let hdrs = Fields::new();
    let resp = OutgoingResponse::new(hdrs);
    let body = resp.body().expect("outgoing response");

    ResponseOutparam::set(outparam, Ok(resp));

    let out = body.write().expect("outgoing stream");
    out.blocking_write_and_flush(b"Hello, wasi:http/proxy world!\n")
        .expect("writing response");

    drop(out);
    OutgoingBody::finish(body, None).unwrap();
}
```