### PR TITLE
Add no_std support.

### DIFF
--- a/crates/wasi-async-runtime/Cargo.toml
+++ b/crates/wasi-async-runtime/Cargo.toml
@@ -12,11 +12,13 @@ categories = []
 authors = ["Yoshua Wuyts <rust@yosh.is>"]
 
 [features]
+default = ["std"]
+std = []
 
 [dependencies]
 wasi = "0.12.1"
-slab = "0.4.9"
-url = "2.5.0"
+slab = { version = "0.4.9", default-features = false }
+hashbrown = "0.14.3"
 
 [dev-dependencies]
 futures-concurrency = "7.4.0"

--- a/crates/wasi-async-runtime/src/block_on.rs
+++ b/crates/wasi-async-runtime/src/block_on.rs
@@ -1,10 +1,10 @@
 use super::Reactor;
 
+use core::future::Future;
 use core::pin::pin;
-use std::future::Future;
-use std::ptr;
-use std::task::Waker;
-use std::task::{Context, Poll, RawWaker, RawWakerVTable};
+use core::ptr;
+use core::task::Waker;
+use core::task::{Context, Poll, RawWaker, RawWakerVTable};
 
 /// Start the event loop
 pub fn block_on<F, Fut>(f: F) -> Fut::Output

--- a/crates/wasi-async-runtime/src/lib.rs
+++ b/crates/wasi-async-runtime/src/lib.rs
@@ -10,6 +10,9 @@
 #![forbid(rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, future_incompatible, unreachable_pub)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 mod block_on;
 mod polling;

--- a/crates/wasi-async-runtime/src/polling.rs
+++ b/crates/wasi-async-runtime/src/polling.rs
@@ -3,6 +3,7 @@
 //! <https://github.com/smol-rs/polling/issues/102> has been resolved, this module
 //! will likely no longer be needed.
 
+use alloc::vec::Vec;
 use slab::Slab;
 use wasi::io::poll::{poll, Pollable};
 

--- a/crates/wasi-async-runtime/src/reactor.rs
+++ b/crates/wasi-async-runtime/src/reactor.rs
@@ -1,9 +1,14 @@
 use super::polling::{EventKey, Poller};
 
+use alloc::rc::Rc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::task::Poll;
+use core::task::Waker;
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
+#[cfg(feature = "std")]
 use std::collections::HashMap;
-use std::task::Poll;
-use std::task::Waker;
-use std::{cell::RefCell, rc::Rc};
 use wasi::io::poll::Pollable;
 
 /// Manage async system resources for WASI 0.2
@@ -67,7 +72,7 @@ impl Reactor {
         let key = reactor.poller.insert(pollable);
         drop(reactor); // NOTE: makes sure we don't hold the lock across the .await
 
-        std::future::poll_fn(|cx| -> Poll<()> {
+        core::future::poll_fn(|cx| -> Poll<()> {
             let mut reactor = self.inner.borrow_mut();
             let waker = cx.waker();
             reactor.wakers.insert(key, waker.clone());


### PR DESCRIPTION
Add no_std support, by following the usual pattern of adding a default "std" feature which can be disabled.

This uses the hashbrown crate to provide `HashMap` in no_std builds.