### PR TITLE
Disable `std` in `wasi` in no-std mode.

### DIFF
--- a/crates/wasi-async-runtime/Cargo.toml
+++ b/crates/wasi-async-runtime/Cargo.toml
@@ -16,7 +16,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-wasi = "0.12.1"
+wasi = { version = "0.12.1", default-features = false }
 slab = { version = "0.4.9", default-features = false }
 hashbrown = "0.14.3"
 


### PR DESCRIPTION
In #2, I forgot that the wasi crate has a std feature that's on by default too.