### PR TITLE
feat(wasi-async-runtime): async wrapper for wasi::io::streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-wasi = "0.12.1"
+wasi = "0.13.2"
 slab = "0.4.9"
 url = "2.5.0"
 wasi-async-runtime = { version = "0.1.2", path = "crates/wasi-async-runtime" }

--- a/crates/wasi-async-runtime/Cargo.toml
+++ b/crates/wasi-async-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-async-runtime"
-version = "0.1.2"
+version = "0.1.3"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yoshuawuyts/wasm-http-tools"
 documentation = "https://docs.rs/wasi-async-runtime"

--- a/crates/wasi-async-runtime/Cargo.toml
+++ b/crates/wasi-async-runtime/Cargo.toml
@@ -13,12 +13,15 @@ authors = ["Yoshua Wuyts <rust@yosh.is>"]
 
 [features]
 default = ["std"]
-std = []
+std = ["futures-lite"]
+futures-lite = ["dep:futures-lite", "dep:bytes"]
 
 [dependencies]
 wasi = { workspace = true }
 slab = { version = "0.4.9", default-features = false }
 hashbrown = "0.14.3"
+futures-lite = { version = "2.3.0", optional = true }
+bytes = { version = "1.7.1", optional = true }
 
 [dev-dependencies]
 futures-concurrency = "7.4.0"

--- a/crates/wasi-async-runtime/Cargo.toml
+++ b/crates/wasi-async-runtime/Cargo.toml
@@ -16,7 +16,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-wasi = "0.12.1"
+wasi = { workspace = true }
 slab = { version = "0.4.9", default-features = false }
 hashbrown = "0.14.3"
 

--- a/crates/wasi-async-runtime/src/block_on.rs
+++ b/crates/wasi-async-runtime/src/block_on.rs
@@ -35,7 +35,7 @@ where
 
 /// Construct a new no-op waker
 // NOTE: we can remove this once <https://github.com/rust-lang/rust/issues/98286> lands
-fn noop_waker() -> Waker {
+pub(crate) fn noop_waker() -> Waker {
     const VTABLE: RawWakerVTable = RawWakerVTable::new(
         // Cloning just returns a new no-op raw waker
         |_| RAW,

--- a/crates/wasi-async-runtime/src/lib.rs
+++ b/crates/wasi-async-runtime/src/lib.rs
@@ -17,6 +17,9 @@ extern crate alloc;
 mod block_on;
 mod polling;
 mod reactor;
+#[cfg(feature = "futures-lite")]
+/// Provides convenience wrappers around [wasi::io::streams]
+pub mod streams;
 
 pub use block_on::block_on;
 pub use reactor::{PollHandle, Reactor};

--- a/crates/wasi-async-runtime/src/lib.rs
+++ b/crates/wasi-async-runtime/src/lib.rs
@@ -19,4 +19,4 @@ mod polling;
 mod reactor;
 
 pub use block_on::block_on;
-pub use reactor::Reactor;
+pub use reactor::{PollHandle, Reactor};

--- a/crates/wasi-async-runtime/src/lib.rs
+++ b/crates/wasi-async-runtime/src/lib.rs
@@ -1,6 +1,6 @@
 //! A single-threaded native runtime for WASI 0.2
 //!
-//! The way to use this is to call [`block_on`] to obtain an instance of
+//! The way to use this is to call [`block_on()`] to obtain an instance of
 //! [`Reactor`]. You can then share the reactor in code that needs it to insert
 //! instances of
 //! [`wasi::Pollable`](https://docs.rs/wasi/latest/wasi/io/poll/struct.Pollable.html).

--- a/crates/wasi-async-runtime/src/streams.rs
+++ b/crates/wasi-async-runtime/src/streams.rs
@@ -1,0 +1,230 @@
+use core::{pin::Pin, task};
+
+use crate::{reactor::PollHandle, Reactor};
+use bytes::{Buf, BytesMut};
+use futures_lite::{io, AsyncBufRead, AsyncRead, AsyncWrite};
+use wasi::io::streams::{
+    InputStream as WasiInputStream, OutputStream as WasiOutputStream,
+    StreamError as WasiStreamError,
+};
+
+const DEFAULT_BUF_LEN: usize = 32;
+
+#[derive(Debug)]
+/// Wraps [wasi::io::streams::InputStream] to enable usage with async libraries.
+pub struct InputStream {
+    inner: WasiInputStream,
+    poll_handle: Option<PollHandle>,
+    buf: BytesMut,
+}
+
+impl InputStream {
+    /// Instatiate the stream.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// block_on(|r| {
+    ///     let lines = InputStream::new(my_wasi_input_stream, r.clone()).lines();
+    ///     while let Some(line) = lines.next().await.transpose()? {
+    ///         eprintln!("Got a line: {line}");
+    ///     }
+    /// });
+    /// ```
+    pub fn new(inner: WasiInputStream, reactor: Reactor) -> Self {
+        let poll_handle = Some(reactor.register(inner.subscribe()));
+        Self {
+            inner,
+            poll_handle,
+            buf: Default::default(),
+        }
+    }
+
+    fn poll(&self, cx: &mut task::Context<'_>) -> task::Poll<()> {
+        self.poll_handle.as_ref().unwrap().poll(cx)
+    }
+}
+
+impl Drop for InputStream {
+    fn drop(&mut self) {
+        // NOTE: we need to drop [PollHandle] first given the resource hierarchy
+        self.poll_handle.take().unwrap();
+    }
+}
+
+impl AsyncRead for InputStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &mut [u8],
+    ) -> task::Poll<std::io::Result<usize>> {
+        if self.poll(cx).is_pending() {
+            return task::Poll::Pending;
+        }
+
+        let mut len = self.buf.remaining();
+        let bytes = match len {
+            0 => match self.inner.read(buf.len() as u64) {
+                Ok(bytes) => bytes,
+                Err(WasiStreamError::Closed) => return task::Poll::Ready(Ok(0)),
+                Err(WasiStreamError::LastOperationFailed(err)) => {
+                    return task::Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        err.to_debug_string(),
+                    )))
+                }
+            },
+            _ => {
+                if buf.len() < len {
+                    len = buf.len();
+                }
+                self.get_mut().buf.copy_to_bytes(len).to_vec()
+            }
+        };
+        let len = bytes.len();
+        bytes.into_iter().enumerate().for_each(|(i, b)| buf[i] = b);
+        task::Poll::Ready(Ok(len))
+    }
+}
+
+impl AsyncBufRead for InputStream {
+    fn poll_fill_buf(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> task::Poll<std::io::Result<&[u8]>> {
+        if self.poll(cx).is_pending() {
+            return task::Poll::Pending;
+        }
+
+        let bytes = match self.inner.read(DEFAULT_BUF_LEN as u64) {
+            Ok(bytes) => bytes,
+            Err(WasiStreamError::Closed) => {
+                return task::Poll::Ready(Ok(self.get_mut().buf.chunk()));
+            }
+            Err(WasiStreamError::LastOperationFailed(err)) => {
+                return task::Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    err.to_debug_string(),
+                )))
+            }
+        };
+        let this = self.get_mut();
+        this.buf.extend(bytes);
+        task::Poll::Ready(Ok(this.buf.chunk()))
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.get_mut().buf.advance(amt);
+    }
+}
+
+#[derive(Debug)]
+/// Wraps [wasi::io::streams::OutputStream] to enable usage with async libraries.
+pub struct OutputStream {
+    inner: WasiOutputStream,
+    poll_handle: Option<PollHandle>,
+}
+
+impl OutputStream {
+    /// Instatiate the stream.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// block_on(|r| {
+    ///     let output = OutputStream::new(my_wasi_output_stream, r.clone());
+    ///     output.write_all("Hello world!\n".as_bytes()).await?;
+    ///     output.flush().await?;
+    /// });
+    /// ```
+    pub fn new(inner: WasiOutputStream, reactor: Reactor) -> Self {
+        let poll_handle = Some(reactor.register(inner.subscribe()));
+        Self { inner, poll_handle }
+    }
+
+    fn poll(&self, cx: &mut task::Context<'_>) -> task::Poll<()> {
+        self.poll_handle.as_ref().unwrap().poll(cx)
+    }
+}
+
+impl Drop for OutputStream {
+    fn drop(&mut self) {
+        // NOTE: we need to drop [PollHandle] first given the resource hierarchy
+        self.poll_handle.take().unwrap();
+    }
+}
+
+impl AsyncWrite for OutputStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &[u8],
+    ) -> task::Poll<io::Result<usize>> {
+        if self.poll(cx).is_pending() {
+            return task::Poll::Pending;
+        }
+
+        let mut n = match self.inner.check_write() {
+            Ok(n) => n as usize,
+            Err(WasiStreamError::Closed) => {
+                return task::Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "stream closed",
+                )));
+            }
+            Err(WasiStreamError::LastOperationFailed(err)) => {
+                return task::Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    err.to_debug_string(),
+                )))
+            }
+        };
+        if buf.len() < n {
+            n = buf.len();
+        }
+
+        match self.inner.write(&buf[..n]) {
+            Ok(()) => {}
+            Err(WasiStreamError::Closed) => {
+                return task::Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "stream closed",
+                )));
+            }
+            Err(WasiStreamError::LastOperationFailed(err)) => {
+                return task::Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    err.to_debug_string(),
+                )))
+            }
+        }
+
+        task::Poll::Ready(Ok(n))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<io::Result<()>> {
+        if self.poll(cx).is_pending() {
+            return task::Poll::Pending;
+        }
+
+        match self.inner.flush() {
+            Ok(()) => task::Poll::Ready(Ok(())),
+            Err(err) => task::Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                match err {
+                    WasiStreamError::Closed => "stream closed".to_owned(),
+                    WasiStreamError::LastOperationFailed(err) => err.to_debug_string(),
+                },
+            ))),
+        }
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<io::Result<()>> {
+        if self.poll(cx).is_pending() {
+            return task::Poll::Pending;
+        }
+
+        // there's no underlying close fn, so flush instead and hope for the best
+        self.poll_flush(cx)
+    }
+}

--- a/crates/wasi-http-client/Cargo.toml
+++ b/crates/wasi-http-client/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["Yoshua Wuyts <rust@yosh.is>"]
 [features]
 
 [dependencies]
-wasi = "0.12.1"
+wasi = { workspace = true }
 slab = "0.4.9"
 url = "2.5.0"
 wasi-async-runtime = { workspace = true }


### PR DESCRIPTION
I know proper streams and async are on their way to the component model, but I wanted something easily usable with preview 2 and made a few modifications to `wasi-async-runtime` to make it a bit nicer to work with `wasi:io/streams` (thanks for making that by the way!!).

I've also put together a demo using these modifications with wasmtime: https://github.com/jvatic/wasi-streams-demo (also happy to move that here as an example for the crate).