### PR TITLE
set wasi dep version to 0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-wasi = "0.12.1"
+wasi = "=0.13.1"
 slab = "0.4.9"
 url = "2.5.0"
-wasi-async-runtime = { version = "0.1.2", path = "crates/wasi-async-runtime" }
+wasi-async-runtime = { version = "0.1.3", path = "crates/wasi-async-runtime" }

--- a/crates/wasi-async-runtime/Cargo.toml
+++ b/crates/wasi-async-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-async-runtime"
-version = "0.1.2"
+version = "0.1.3"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yoshuawuyts/wasm-http-tools"
 documentation = "https://docs.rs/wasi-async-runtime"
@@ -16,8 +16,8 @@ default = ["std"]
 std = []
 
 [dependencies]
-wasi = "0.12.1"
-slab = { version = "0.4.9", default-features = false }
+wasi = { workspace = true }
+slab = { workspace  = "0.4.9", default-features = false }
 hashbrown = "0.14.3"
 
 [dev-dependencies]

--- a/crates/wasi-http-client/Cargo.toml
+++ b/crates/wasi-http-client/Cargo.toml
@@ -14,9 +14,9 @@ authors = ["Yoshua Wuyts <rust@yosh.is>"]
 [features]
 
 [dependencies]
-wasi = "0.12.1"
-slab = "0.4.9"
-url = "2.5.0"
+wasi = { workspace = true }
+slab = { workspace = true }
+url = { workspace = true }
 wasi-async-runtime = { workspace = true }
 async-iterator = "2.3.0"
 


### PR DESCRIPTION
Updates the dep `wasi` crate to version `0.13.1` (WASI 0.2.0). WASI 0.2.1 is still making its way through tooling updates.

Also, accordingly version bumps `wasi-async-runtime` crate.